### PR TITLE
add code and web content highlighting

### DIFF
--- a/oma-profile/oma/css/oma.css
+++ b/oma-profile/oma/css/oma.css
@@ -255,22 +255,23 @@ aside.web-content, aside.code-content {
   padding: .5em;
   margin: 1em 0;
 }
+
+.code-content-title, .web-content-title {
+  text-transform: uppercase;
+}
+
+aside.code-content {
+  border-left: .5em solid #AF6EE8;
+  background: #EED2FF;
+}
+
 aside.web-content {
   border-left: .5em solid #5596E6;
   background: #C0E6FF;
 }
 
-.code-content-title, .web-content-title {
-  text-transform: uppercase;
-}
-aside.code-content {
-  border-left: .5em solid #AF6EE8;
-  background: #EED2FF;  /* 10 */
-}
-
-
-.code-content-title { color: #9855D4; } /* light gray */
-.web-content-title { color: #4178BE; } /* light blue */
+.code-content-title { color: #9855D4; }
+.web-content-title { color: #4178BE; }
 
 .content-inner {
     margin-left: 12px;

--- a/oma-profile/oma/css/oma.css
+++ b/oma-profile/oma/css/oma.css
@@ -243,3 +243,42 @@ figure  {
 strong.highlight {
   background: yellow;
 }
+
+
+/* --- CUSTOM CONTENT --- */
+aside.web-content, aside.code-content {
+  padding: .5em;
+  margin: 1em 0;
+}
+aside.web-content {
+  border-left: .5em solid #5596E6;
+  background: #C0E6FF;
+}
+
+.code-content-title, .web-content-title {
+  text-transform: uppercase;
+}
+
+.code-content-title { color: #777677; } /* light gray */
+.web-content-title { color: #4178BE; } /* light blue */
+
+aside.code-content {
+  border-left: .5em solid #C7C7C7;
+  background: #E0E0E0;
+}
+
+.content-inner {
+    margin-left: 12px;
+}
+
+.code-content > code {
+  margin: 12px;
+}
+
+.web-content > .content-inner {
+    background: #E0E0E0;
+    border: 1px solid #959595;
+    margin: 1em 0;
+    border-radius: .25em;
+    padding: 6px;
+}

--- a/oma-profile/oma/css/oma.css
+++ b/oma-profile/oma/css/oma.css
@@ -246,6 +246,11 @@ strong.highlight {
 
 
 /* --- CUSTOM CONTENT --- */
+/*
+  background: 10
+  border: 40
+  title: 50
+*/
 aside.web-content, aside.code-content {
   padding: .5em;
   margin: 1em 0;
@@ -258,14 +263,14 @@ aside.web-content {
 .code-content-title, .web-content-title {
   text-transform: uppercase;
 }
-
-.code-content-title { color: #777677; } /* light gray */
-.web-content-title { color: #4178BE; } /* light blue */
-
 aside.code-content {
-  border-left: .5em solid #C7C7C7;
-  background: #E0E0E0;
+  border-left: .5em solid #AF6EE8;
+  background: #EED2FF;  /* 10 */
 }
+
+
+.code-content-title { color: #9855D4; } /* light gray */
+.web-content-title { color: #4178BE; } /* light blue */
 
 .content-inner {
     margin-left: 12px;

--- a/oma-profile/oma/style.js
+++ b/oma-profile/oma/style.js
@@ -18,7 +18,7 @@ define(
                 $("body").addClass(conf.specStatus);
 
                 $(".web-content").wrapInner("<div class=\"content-inner\"></div>");
-                $(".code-content").wrapInner("<code class=\"highlight\"></code>");
+                $(".code-content").wrapInner("<pre class=\"highlight\"></pre>");
 
                 $(".web-content").each(function(index, elem) {
                     $elem = $(elem);

--- a/oma-profile/oma/style.js
+++ b/oma-profile/oma/style.js
@@ -11,12 +11,25 @@ define(
                                  .text(css);
                 }
 
-
                 // core/highlight expects there to be a link tag to append
                 // highlight specific css to.
                 $("<link />").appendTo("head");
-                
+
                 $("body").addClass(conf.specStatus);
+
+                $(".web-content").wrapInner("<div class=\"content-inner\"></div>");
+                $(".code-content").wrapInner("<code class=\"highlight\"></code>");
+
+                $(".web-content").each(function(index, elem) {
+                    $elem = $(elem);
+                    $elem.prepend("<div class=\"web-content-title\">Web Content</div>");
+                });
+
+                $(".code-content").each(function(index, elem) {
+                    $elem = $(elem);
+                    $elem.prepend("<div class=\"code-content-title\">Code Content</div>");
+                });
+
                 msg.pub("end", "oma/style");
                 cb();
             }


### PR DESCRIPTION
References issue https://github.com/OpenMobileAlliance/Tools/issues/5

Both Web and Code content are tagged using an aside with the `web-content` and `code-content` tags respectively. `code-content` is automatically highlighted, and none of these sections are numbered. 

```html      
<aside class="web-content">
    this is how it looks!
    <p>and another pagraph <abbr>test</abbr></p>
</aside>

<aside class="code-content">
&lt;pre>some example code&lt;/pre>
</aside>
```

**Sample Display**

![code-web-grab](https://cloud.githubusercontent.com/assets/385/7560219/bf5b226a-f775-11e4-96d2-2d41be6c7199.png)


@jpradocueva what do you think of the style and markup used to generate?